### PR TITLE
chore(wicek): bump chart to 0.1.79 (HA MCP + Apple Calendar)

### DIFF
--- a/apps/wicek/chart.yaml
+++ b/apps/wicek/chart.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: wicek
     repoURL: https://xxczaki.github.io/charts/
-    targetRevision: 0.1.78
+    targetRevision: 0.1.79
     helm:
       valuesObject:
         secrets:


### PR DESCRIPTION
Points the wicek Argo CD app at chart `0.1.79`, which pins the new wicek image (`170fc486…`) carrying the Home Assistant MCP server config + the Apple Calendar skill. Activates both features (secrets / env / egress already merged via #748 and #749).

🤖 Generated with [Claude Code](https://claude.com/claude-code)