### PR TITLE
chore(wicek): bump chart to 0.1.80 (pod fixes)

### DIFF
--- a/apps/wicek/chart.yaml
+++ b/apps/wicek/chart.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: wicek
     repoURL: https://xxczaki.github.io/charts/
-    targetRevision: 0.1.79
+    targetRevision: 0.1.80
     helm:
       valuesObject:
         secrets:


### PR DESCRIPTION
Deploys the wicek image with the **bash** fix (Bash tool / skills work in the pod) + **stale-session resilience**. Points the Argo CD app at chart `0.1.80`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)