### PR TITLE
chore(wicek): bump chart to 0.1.81 (pod fixes)

### DIFF
--- a/apps/wicek/chart.yaml
+++ b/apps/wicek/chart.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: wicek
     repoURL: https://xxczaki.github.io/charts/
-    targetRevision: 0.1.80
+    targetRevision: 0.1.81
     helm:
       valuesObject:
         secrets:


### PR DESCRIPTION
Deploys the wicek image (`186ad4c`) with the **bash** fix + **stale-session resilience** (#52). `0.1.80` was Renovate's SDK bump and did not include these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)