### PR TITLE
fix(pi-hole): stable ULA for IPv6 DNS LoadBalancer

### DIFF
--- a/apps/cilium/ip-pools.yaml
+++ b/apps/cilium/ip-pools.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   blocks:
     - cidr: "10.10.10.53/32"
-    - cidr: "fe80::c196:2a41:e1c0:79d7/64"
+    - cidr: "fd2b:55e1:1a4c:10::53/128"  # ULA for Pi-hole IPv6 DNS; L2/NDP-announced on eth0, advertised to LAN clients via UniFi RDNSS
   serviceSelector:
     matchLabels:
       app: pihole

--- a/apps/pi-hole/application.yaml
+++ b/apps/pi-hole/application.yaml
@@ -81,7 +81,7 @@ spec:
           enabled: false
 
         dualStack:
-          enabled: true
+          enabled: true  # IPv6 DNS served at ULA fd2b:55e1:1a4c:10::53 (see Cilium pi-hole-pool), advertised to LAN via UniFi RDNSS. ULA is ISP-prefix-independent, so it survives Telekom prefix rotation.
 
         extraEnvVars:
           TZ: "Europe/Warsaw"


### PR DESCRIPTION
## What

Replaces the Cilium `pi-hole-pool` IPv6 block from a link-local `fe80::c196:2a41:e1c0:79d7/64` to a stable ULA `fd2b:55e1:1a4c:10::53/128`.

## Why

The dualStack IPv6 DNS LoadBalancer was being assigned a **link-local** address, which is unroutable and unusable as a resolver – so IPv6 DNS via the LB never actually worked (clients could only reach Pi-hole over IPv4 or Tailscale).

A ULA (RFC 4193, random global ID) is independent of the **dynamic Telekom-delegated prefix**, so it survives prefix rotation – unlike a GUA, which would break on every reconnect. Telekom does not offer static prefixes to consumers.

## Rollout

1. Merge → Argo syncs → Cilium reassigns the IPv6 LB to `fd2b:55e1:1a4c:10::53` and NDP-announces it on eth0.
2. UniFi: add ULA `fd2b:55e1:1a4c:10::1/64` under the LAN's **Additional IPs**, and set **DHCPv6/RDNSS DNS Control** to `fd2b:55e1:1a4c:10::53`.
3. Verify clients land on Pi-hole over IPv6 via FTL stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)