### PR TITLE
chore(wicek): bump chart to 0.1.108 (UniFi access instructions)

### DIFF
--- a/apps/wicek/chart.yaml
+++ b/apps/wicek/chart.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: wicek
     repoURL: https://xxczaki.github.io/charts/
-    targetRevision: 0.1.107
+    targetRevision: 0.1.108
     helm:
       valuesObject:
         secrets:


### PR DESCRIPTION
Deploys the wicek image carrying the UniFi access docs (xxczaki/wicek#79). Creds env already live as of 0.1.107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)