### PR TITLE
fix(cilium): pin to 1.19.1 to dodge IPv6 SNAT BPF load failure

### DIFF
--- a/apps/cilium/application.yaml
+++ b/apps/cilium/application.yaml
@@ -8,7 +8,16 @@ spec:
   source:
     chart: cilium
     repoURL: https://helm.cilium.io/
-    targetRevision: 1.19.4
+    # PINNED to 1.19.1 — do NOT bump on this node until it runs a BTF-enabled kernel.
+    # Cilium >=1.19.2 made the IPv6 SNAT helpers global BPF functions
+    # (cilium/cilium#44544, #45007); the verifier can only validate them with
+    # vmlinux BTF, which Raspberry Pi OS kernels don't ship (no CONFIG_DEBUG_INFO_BTF).
+    # Result on >=1.19.2: cilium_host fails to load tail_handle_snat_fwd_ipv6, the
+    # LoadBalancer/L2 datapath can't program, and Pi-hole's LB IP goes unreachable
+    # (cilium/cilium#45224). Cilium now REQUIRES BTF (#46063; inline fallback #45626
+    # was closed), so the durable fix is a BTF kernel (e.g. Ubuntu for Pi), not a
+    # Cilium upgrade. 1.19.1 predates the change and keeps IPv6 LB + L2 working.
+    targetRevision: 1.19.1
     helm:
       valuesObject:
         k8sServiceHost: 10.10.10.10
@@ -29,7 +38,7 @@ spec:
         bpf:
           # Belt-and-braces: the same BTF bug would also break the IPv6 SNAT
           # codepath if BPF masquerade were re-enabled. Iptables masquerade
-          # stays until raspberrypi/linux#6622 / cilium/cilium#45626 land.
+          # stays (same BTF bug, cilium/cilium#45224 — see the targetRevision pin above).
           masquerade: false
         kubeProxyReplacement: true
         socketLB:


### PR DESCRIPTION
## Problem
On Cilium **1.19.4**, the agent can't load `tail_handle_snat_fwd_ipv6` (`Caller passes invalid args into func#1 ('__snat_v6_nat')`). This fails `cilium_host` endpoint regeneration, so the LoadBalancer/L2-announcement datapath can't be programmed and `10.10.10.53` (Pi-hole) became unreachable on the LAN — which took the network's DNS down.

## Root cause
Cilium >=1.19.2 converted the IPv6 SNAT helpers to **global BPF functions** ([#44544](https://github.com/cilium/cilium/pull/44544), [#45007](https://github.com/cilium/cilium/pull/45007)). Validating those requires **vmlinux BTF**, which stock Raspberry Pi OS kernels (`6.12.75+rpt-rpi-2712`, no `CONFIG_DEBUG_INFO_BTF`) don't ship → [cilium/cilium#45224](https://github.com/cilium/cilium/issues/45224) (exact-env match). Cilium now **requires** BTF ([#46063](https://github.com/cilium/cilium/pull/46063); inline fallback [#45626](https://github.com/cilium/cilium/pull/45626) was closed).

## Fix
Pin to **1.19.1** (predates the global-function change). Keeps IPv6 LB + L2 announcements. Durable fix = BTF-enabled kernel (e.g. Ubuntu for Pi), documented in-line; do not bump past 1.19.1 until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)