### PR TITLE
chore(renovate): hold Cilium below 1.19.2 (BTF bug)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
 			"description": "Schedule discord-bot updates between 3 AM and 8 PM",
 			"matchPackageNames": ["discord-bot"],
 			"schedule": ["* 3-20 * * *"]
+		},
+		{
+			"description": "Hold Cilium below 1.19.2: >=1.19.2 makes the IPv6 SNAT helpers global BPF functions that need vmlinux BTF, which the Raspberry Pi OS kernel lacks — breaks the LB/L2 datapath (cilium/cilium#45224). Unpin once the node runs a BTF-enabled kernel. See apps/cilium/application.yaml.",
+			"matchPackageNames": ["cilium"],
+			"allowedVersions": "<1.19.2"
 		}
 	],
 	"ignoreTests": true


### PR DESCRIPTION
Caps the Cilium chart at `<1.19.2` in Renovate so it stops proposing bumps that reintroduce the IPv6 SNAT BPF/BTF failure ([cilium/cilium#45224](https://github.com/cilium/cilium/issues/45224)) — paired with the pin in [#784](https://github.com/xxczaki/homelab/pull/784).

`<1.19.2` (vs a blanket disable) encodes the exact bug boundary and auto-resumes updates once the rule is removed. Remove it when the node runs a BTF-enabled kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)