### PR TITLE
fix(alerting): route cluster alerts to OnCall via Grafana-managed rules

### DIFF
--- a/terraform/grafana/rules.tf
+++ b/terraform/grafana/rules.tf
@@ -1,0 +1,513 @@
+# Grafana-managed alert rules.
+#
+# These were previously PrometheusRule CRDs synced into the Mimir ruler by
+# Alloy (apps/alerting-rules). Mimir-managed alerts route to the cloud
+# Alertmanager, which has no notification config, so they never reached
+# OnCall. Defining them as Grafana-managed rules routes them through the
+# Grafana Alertmanager -> notification policy -> Grafana OnCall / Discord.
+
+locals {
+  # Cloud Prometheus (Mimir) data source the rules query against.
+  prom_ds_uid = "grafanacloud-prom"
+}
+
+resource "grafana_folder" "cluster_alerts" {
+  title = "Cluster Alerts"
+}
+
+# A reusable instant PromQL query (ref A) -> reduce last (ref B) -> threshold
+# (ref C). The alert condition is always ref C.
+#
+# Each rule below keeps the original PromQL but moves the firing comparison out
+# of the query and into the threshold expression, so $values.B.Value still
+# exposes the underlying metric value for annotations.
+
+resource "grafana_rule_group" "pod_health" {
+  name             = "pod-health"
+  folder_uid       = grafana_folder.cluster_alerts.uid
+  interval_seconds = 60
+
+  rule {
+    name      = "PodCrashLoopBackOff"
+    condition = "C"
+    for       = "5m"
+
+    data {
+      ref_id         = "A"
+      datasource_uid = local.prom_ds_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        datasource    = { type = "prometheus", uid = local.prom_ds_uid }
+        expr          = "kube_pod_container_status_waiting_reason{reason=\"CrashLoopBackOff\"}"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "B"
+        type       = "reduce"
+        expression = "A"
+        reducer    = "last"
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "threshold"
+        expression = "B"
+        datasource = { type = "__expr__", uid = "__expr__" }
+        conditions = [{ evaluator = { type = "gt", params = [0] } }]
+      })
+    }
+
+    labels         = { severity = "critical" }
+    annotations    = { summary = "Pod {{ $labels.namespace }}/{{ $labels.pod }} is in CrashLoopBackOff" }
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+  }
+
+  rule {
+    name      = "PodHighRestartRate"
+    condition = "C"
+    for       = "10m"
+
+    data {
+      ref_id         = "A"
+      datasource_uid = local.prom_ds_uid
+      relative_time_range {
+        from = 3600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        datasource    = { type = "prometheus", uid = local.prom_ds_uid }
+        expr          = "increase(kube_pod_container_status_restarts_total[1h])"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "B"
+        type       = "reduce"
+        expression = "A"
+        reducer    = "last"
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "threshold"
+        expression = "B"
+        datasource = { type = "__expr__", uid = "__expr__" }
+        conditions = [{ evaluator = { type = "gt", params = [5] } }]
+      })
+    }
+
+    labels         = { severity = "warning" }
+    annotations    = { summary = "Pod {{ $labels.namespace }}/{{ $labels.pod }} restarted {{ humanize $values.B.Value }} times in the last hour" }
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+  }
+
+  rule {
+    name      = "PodNotReady"
+    condition = "C"
+    for       = "15m"
+
+    data {
+      ref_id         = "A"
+      datasource_uid = local.prom_ds_uid
+      relative_time_range {
+        from = 900
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        datasource    = { type = "prometheus", uid = local.prom_ds_uid }
+        expr          = "min_over_time(kube_pod_status_ready{condition=\"true\"}[15m])"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "B"
+        type       = "reduce"
+        expression = "A"
+        reducer    = "last"
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "threshold"
+        expression = "B"
+        datasource = { type = "__expr__", uid = "__expr__" }
+        conditions = [{ evaluator = { type = "lt", params = [1] } }]
+      })
+    }
+
+    labels         = { severity = "warning" }
+    annotations    = { summary = "Pod {{ $labels.namespace }}/{{ $labels.pod }} has not been ready for 15m" }
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+  }
+
+  rule {
+    name      = "PodPending"
+    condition = "C"
+    for       = "15m"
+
+    data {
+      ref_id         = "A"
+      datasource_uid = local.prom_ds_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        datasource    = { type = "prometheus", uid = local.prom_ds_uid }
+        expr          = "kube_pod_status_phase{phase=\"Pending\"}"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "B"
+        type       = "reduce"
+        expression = "A"
+        reducer    = "last"
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "threshold"
+        expression = "B"
+        datasource = { type = "__expr__", uid = "__expr__" }
+        conditions = [{ evaluator = { type = "gt", params = [0] } }]
+      })
+    }
+
+    labels         = { severity = "warning" }
+    annotations    = { summary = "Pod {{ $labels.namespace }}/{{ $labels.pod }} stuck in Pending" }
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+  }
+}
+
+resource "grafana_rule_group" "node_health" {
+  name             = "node-health"
+  folder_uid       = grafana_folder.cluster_alerts.uid
+  interval_seconds = 60
+
+  rule {
+    name      = "NodeNotReady"
+    condition = "C"
+    for       = "5m"
+
+    data {
+      ref_id         = "A"
+      datasource_uid = local.prom_ds_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        datasource    = { type = "prometheus", uid = local.prom_ds_uid }
+        expr          = "kube_node_status_condition{condition=\"Ready\",status=\"true\"}"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "B"
+        type       = "reduce"
+        expression = "A"
+        reducer    = "last"
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "threshold"
+        expression = "B"
+        datasource = { type = "__expr__", uid = "__expr__" }
+        conditions = [{ evaluator = { type = "lt", params = [1] } }]
+      })
+    }
+
+    labels         = { severity = "critical" }
+    annotations    = { summary = "Node {{ $labels.node }} is not ready" }
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+  }
+
+  rule {
+    name      = "NodeHighCpuUsage"
+    condition = "C"
+    for       = "15m"
+
+    data {
+      ref_id         = "A"
+      datasource_uid = local.prom_ds_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        datasource    = { type = "prometheus", uid = local.prom_ds_uid }
+        expr          = "(1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))) * 100"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "B"
+        type       = "reduce"
+        expression = "A"
+        reducer    = "last"
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "threshold"
+        expression = "B"
+        datasource = { type = "__expr__", uid = "__expr__" }
+        conditions = [{ evaluator = { type = "gt", params = [85] } }]
+      })
+    }
+
+    labels         = { severity = "warning" }
+    annotations    = { summary = "CPU usage above 85% on {{ $labels.instance }} ({{ humanize $values.B.Value }}%)" }
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+  }
+
+  rule {
+    name      = "NodeHighMemoryUsage"
+    condition = "C"
+    for       = "10m"
+
+    data {
+      ref_id         = "A"
+      datasource_uid = local.prom_ds_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        datasource    = { type = "prometheus", uid = local.prom_ds_uid }
+        expr          = "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "B"
+        type       = "reduce"
+        expression = "A"
+        reducer    = "last"
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "threshold"
+        expression = "B"
+        datasource = { type = "__expr__", uid = "__expr__" }
+        conditions = [{ evaluator = { type = "gt", params = [90] } }]
+      })
+    }
+
+    labels         = { severity = "warning" }
+    annotations    = { summary = "Memory usage above 90% on {{ $labels.instance }} ({{ humanize $values.B.Value }}%)" }
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+  }
+}
+
+resource "grafana_rule_group" "storage" {
+  name             = "storage"
+  folder_uid       = grafana_folder.cluster_alerts.uid
+  interval_seconds = 120
+
+  rule {
+    name      = "PVCUsageHigh"
+    condition = "C"
+    for       = "15m"
+
+    data {
+      ref_id         = "A"
+      datasource_uid = local.prom_ds_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        datasource    = { type = "prometheus", uid = local.prom_ds_uid }
+        expr          = "(kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) * 100"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+    data {
+      ref_id         = "B"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "B"
+        type       = "reduce"
+        expression = "A"
+        reducer    = "last"
+        datasource = { type = "__expr__", uid = "__expr__" }
+      })
+    }
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "threshold"
+        expression = "B"
+        datasource = { type = "__expr__", uid = "__expr__" }
+        conditions = [{ evaluator = { type = "gt", params = [85] } }]
+      })
+    }
+
+    labels         = { severity = "warning" }
+    annotations    = { summary = "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is {{ humanize $values.B.Value }}% full" }
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+  }
+}


### PR DESCRIPTION
## Problem

The on-call setup never pings on cluster breakage. Root cause: the alert **rules** and the **notification wiring** live in two different Alertmanagers.

- `cluster-alerts` is a `PrometheusRule` CRD, synced by Alloy (`mimir.rules.kubernetes`) into the Grafana Cloud **Mimir ruler**. Confirmed loaded & evaluating live.
- Mimir-managed alerts route to the **cloud Alertmanager** (`grafanacloud-ngalertmanager`) – whose config is **completely empty** (`{"alertmanager_config": {}}`). Alerts fire into a void.
- The OnCall integration, escalation chains, contact points and notification policy (Terraform) all live in the **Grafana-managed Alertmanager**, which never receives these alerts (0 alerts present live; Grafana ruler has 0 rules).

## Fix

Re-express the 8 alerts as **Grafana-managed** rules (`grafana_rule_group`, query → reduce → threshold) in a "Cluster Alerts" folder, querying the `grafanacloud-prom` datasource. Grafana evaluates them and routes through the existing notification policy → **Grafana OnCall** (root receiver) / **Discord** (`namespace=discord-bot`).

`terraform plan`: **4 to add, 0 change, 0 destroy** (1 folder + 3 rule groups). Purely additive.

## Notes / follow-ups

- The duplicate `apps/alerting-rules` PrometheusRule path is **not** removed here – kept until these rules are confirmed firing, then removed in a follow-up PR.
- OnCall is the root receiver, so `notify_persons` still depends on your **personal OnCall notification rules** (verified phone / mobile push) being set in the UI – that can't be Terraformed.
- This is a VCS-driven TFC workspace, so merging triggers the apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)