### PR TITLE
feat(wicek): map GH_TOKEN into the pod env

### DIFF
--- a/apps/wicek/chart.yaml
+++ b/apps/wicek/chart.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: wicek
     repoURL: https://xxczaki.github.io/charts/
-    targetRevision: 0.1.115
+    targetRevision: 0.1.119
     helm:
       valuesObject:
         secrets:
@@ -18,6 +18,9 @@ spec:
           discordToken:
             name: wicek-secrets
             key: DISCORD_BOT_TOKEN
+          ghToken:
+            name: wicek-secrets
+            key: GH_TOKEN
           grafanaApiKey:
             name: wicek-secrets
             key: GRAFANA_API_KEY


### PR DESCRIPTION
## Problem

`gh` is installed in the Wicek pod but unauthenticated — no `GH_TOKEN` reached the environment, even though `wicek-secrets` already holds the key. The agent had to fall back to a repo-scoped deploy key to push.

## Change

- Add `secrets.ghToken -> wicek-secrets/GH_TOKEN` to the chart values.
- Bump `targetRevision` 0.1.115 -> 0.1.118 (picks up the new `GH_TOKEN` env block).

## Ordering

Depends on xxczaki/charts#24 — merge and let the chart publish to gh-pages **first**, otherwise ArgoCD can't resolve 0.1.118. Auto-heal will reconcile once 0.1.118 is published. No secret change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)