### PR TITLE
feat(alerting): add OnCall heartbeat integration (dead man's switch)

### DIFF
--- a/terraform/grafana/oncall.tf
+++ b/terraform/grafana/oncall.tf
@@ -48,3 +48,17 @@ resource "grafana_oncall_route" "critical" {
   routing_regex       = "\"severity\": \"critical\""
   position            = 0
 }
+
+# --- Heartbeat: dead man's switch ---
+#
+# An in-cluster CronJob pings this integration's heartbeat URL; OnCall fires
+# through the critical chain when the pings stop. The interval and ping URL are
+# configured in the OnCall UI (the provider exposes neither).
+resource "grafana_oncall_integration" "heartbeat" {
+  name = "Cluster Heartbeat"
+  type = "webhook"
+
+  default_route {
+    escalation_chain_id = grafana_oncall_escalation_chain.critical.id
+  }
+}

--- a/terraform/grafana/outputs.tf
+++ b/terraform/grafana/outputs.tf
@@ -1,0 +1,6 @@
+# Link of the Cluster Heartbeat integration. Sensitive: the link embeds a token.
+output "heartbeat_integration_link" {
+  description = "Link of the Cluster Heartbeat OnCall integration."
+  value       = grafana_oncall_integration.heartbeat.link
+  sensitive   = true
+}


### PR DESCRIPTION
## What

Adds a `Cluster Heartbeat` OnCall integration routed to the existing **critical** escalation chain, plus a sensitive output for its link. A companion PR (#820) adds an in-cluster CronJob that pings the heartbeat URL; OnCall pages when the pings stop — a dead man's switch that covers full outages.

- `grafana_oncall_integration.heartbeat` (type `webhook`) → `default_route` → critical chain
- sensitive `heartbeat_integration_link` output

## Provider limitation / follow-up

The `grafana ~> 4.38` provider has **no heartbeat block**: the interval is UI-only and the ping URL (embeds a token) only exists after apply. After this applies via TFC:

1. OnCall UI → Integrations → Cluster Heartbeat → Heartbeat: set the interval and copy the ping URL.
2. Seal that URL into the cluster and merge #820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)