### PR TITLE
feat(alerting): add OnCall heartbeat ping CronJob

### DIFF
--- a/apps/heartbeat/application.yaml
+++ b/apps/heartbeat/application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: heartbeat
+  namespace: monitoring
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/xxczaki/homelab
+    path: apps/heartbeat/resources
+    targetRevision: HEAD
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/apps/heartbeat/resources/cronjob.yaml
+++ b/apps/heartbeat/resources/cronjob.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: oncall-heartbeat
+  namespace: monitoring
+spec:
+  # Ping every 2 minutes. The OnCall heartbeat interval (set in the UI) should be
+  # higher (e.g. 10m) so a single missed ping from a transient blip does not page,
+  # but a real outage pages within minutes.
+  schedule: "*/2 * * * *"
+  timeZone: Europe/Berlin
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 60
+      ttlSecondsAfterFinished: 600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          # No tolerations on purpose: if the node is cordoned, these pods must
+          # stay Pending and fail to ping, so OnCall pages. The silence is the alarm.
+          containers:
+            - name: curl
+              image: curlimages/curl:8.11.1
+              command:
+                - sh
+                - -c
+                - 'curl -fsS --retry 3 --retry-delay 5 --max-time 30 -o /dev/null "$HEARTBEAT_URL"'
+              env:
+                - name: HEARTBEAT_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: oncall-heartbeat
+                      key: url
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  memory: 32Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+                runAsNonRoot: true
+                runAsUser: 65534
+                seccompProfile:
+                  type: RuntimeDefault

--- a/apps/heartbeat/resources/sealed-secret.yaml
+++ b/apps/heartbeat/resources/sealed-secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: oncall-heartbeat
+  namespace: monitoring
+spec:
+  encryptedData:
+    url: AgAG4b+OA7WE2c8Pzg1sz0UNsbH1PRICD0T8v/3CWYIhxvm4imTqTDUPOuFLMbnjPZDUs8dTGJ4+S2d8JnTGmKitZJ6AuFlRDUfnIinHhCIeT9bVTiHwQvnkXHYYb7IUQlxGRoEkpcWoN/XoUlpnmBrMdDv0kYn2JQvDHgfg4SIiORbjWRSCH8Rn05B1caEU6Vkga5QHan3k+1u3298Ua2fOOXNRWYz49bWODN8mehrMgx3n/v9nh/R02WGf6DSYXipQ74MjEBty0kEZ5xscVdyXmqxLwcuXX1n7Yw4gASNHZQEvSlTg3+hb9NVydcjSkTmRNQNECEzhJt41fVRZ8pyv5AEM5gR3rtL8xQAr/KnUSDFuKYnEXZLqPCMw+4x3p/10W4sDY8FuDlS40xNC4FEbvedz19SQY72ePxricR9UTherANknxrGE5VHsgS+WjlXU0MJxzCpcIPIW5tQq9Uze9uKWySv9bcrJFsNBiZzOu/giFI6Fb+opWFTD6vMDuwubk98K9DtgGjeZzVzooAfXWThT4Vpn0MAUKvoUsHiDSaDrfryB6I/W3+wTDqNP69Ne+leqwv1eHziMMakRgz8OhzIf29/INFumzS1w8sTQdb7wrQe5N2O+rzmwAk6Xy1dp+x44xKdUdUq+BgqUsaWqQMqoXsDFfQtjUQOHc+o3WonWjWgCnVZ6oDKM6Z8Mn27UQmYjtvA7DnjVrrKc+HB0eMF0HkWhKqzPIGHB96c1PPcoP88lwBxw/9zjJpbeT62xUC+UKQ7dBHzXmWw2lbb1cHr223lcf8YYenS63K24Rtm6jKwsAMxxS5MKcspxqi5Edu9jyu2QRKvvH79t
+  template:
+    metadata:
+      name: oncall-heartbeat
+      namespace: monitoring
+    type: Opaque

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Single-node [K3s](https://k3s.io) cluster managed entirely through [Argo CD](htt
 | [argo-cd](apps/argo-cd) | Helm | v9.7.1 |
 | [cilium](apps/cilium) | Helm | v1.19.1 |
 | [discord-bot](apps/discord-bot) | Helm | v0.23.0 |
+| [heartbeat](apps/heartbeat) | Git | - |
 | [k8s-monitoring](apps/k8s-monitoring) | Helm | v4.1.6 |
 | [longhorn](apps/longhorn) | Helm | v1.12.0 |
 | [pi-hole](apps/pi-hole) | Helm | v2.36.0 |

--- a/scripts/seal-secrets.sh
+++ b/scripts/seal-secrets.sh
@@ -19,6 +19,7 @@ declare -A secret_map=(
   [traces-grafana-k8s-monitoring-secret.yaml]="apps/k8s-monitoring/traces-secret.yaml"
   [longhorn-backblaze-b2-secret.yaml]="apps/longhorn/backblaze-b2-secret.yaml"
   [tailscale-operator-oauth-secret.yaml]="apps/tailscale/oauth-secret.yaml"
+  [oncall-heartbeat-secret.yaml]="apps/heartbeat/resources/sealed-secret.yaml"
 )
 
 for path in secrets/*.yaml; do


### PR DESCRIPTION
## What

Companion to #819. That PR adds the `Cluster Heartbeat` OnCall integration; this adds the in-cluster pinger that keeps it alive. When the pings stop, OnCall pages off the critical chain — a dead man's switch.

- `apps/heartbeat/` — ArgoCD Application + CronJob in the `monitoring` namespace, pings the heartbeat URL every 2 min.
  - **No tolerations on purpose**: if the node is cordoned the ping pods stay `Pending` and can't ping → OnCall pages.
- `scripts/seal-secrets.sh` — seal mapping for the heartbeat URL secret.
- `readme.md` — regenerated apps table (adds `heartbeat`, drops the already-removed `alerting-rules` row).

## ⚠️ Draft — blocked on the sealed secret

The ping URL only exists **after #819 applies**. Sequence:

1. Merge #819 → TFC creates the integration.
2. OnCall UI → Cluster Heartbeat → Heartbeat: set the interval, copy the ping URL.
3. Fill `secrets/oncall-heartbeat-secret.yaml` → run `scripts/seal-secrets.sh` → produces `apps/heartbeat/resources/sealed-secret.yaml`.
4. Commit the sealed secret to this branch, mark ready, merge.

Merging before the sealed secret exists will crashloop the CronJob on a missing secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)